### PR TITLE
fix: reinvert to keep the same colors in night mode

### DIFF
--- a/pencil.koplugin/main.lua
+++ b/pencil.koplugin/main.lua
@@ -1708,6 +1708,12 @@ function Pencil:showColorPicker(x, y)
         current_color_name = self.tool_settings[TOOL_PEN].color_name,
         callback = function(color_value, color_name)
             plugin:setPenColor(color_value, color_name)
+
+            -- Display white as the color name if black is picked in night mode
+            if Screen.night_mode and color_name == "Black" then
+                color_name = "White"
+            end
+
             UIManager:show(InfoMessage:new{
                 text = T(_("Pen color: %1"), color_name),
                 timeout = 1,


### PR DESCRIPTION
Visually inverts the selected color and swatch colors so that they are the same in night mode.
Although this deviates from the stock behavior on Kobo devices (Nickel), it doesn't properly support night mode either with only an inconvenient "Invert Screen" option in developer options which also inverts covers. For the purposes of stylus annotations, it is better to maintain color consistency for use and parity with highlights.

### Light Mode
<img width="500" alt="image" src="https://github.com/user-attachments/assets/b9bf8253-f46a-40cc-a282-d53f0dd142fa" />

### Night Mode

_**Before**_:
<img width="500" alt="image" src="https://github.com/user-attachments/assets/03f464c6-07de-4d30-9bb4-fbb11e04ea7e" />

_**After**_:
<img width="500" alt="image" src="https://github.com/user-attachments/assets/ed26018d-efa2-4986-b5ca-0ba14efd17a6" />