### PR TITLE
fix: use getTopmostVisibleWidget so invisible decorations don't gate stylus input

### DIFF
--- a/pencil.koplugin/main.lua
+++ b/pencil.koplugin/main.lua
@@ -798,17 +798,12 @@ end
 -- Check if a menu or overlay is shown on top of the reader view.
 -- When true, pen input should pass through so the overlay can handle it.
 function Pencil:isOverlayActive()
-    local stack = UIManager._window_stack
-    if not stack or #stack == 0 then return false end
-    local top = stack[#stack]
-    if top and top.widget then
-        local name = top.widget.name or top.widget.id
-        -- ReaderUI is the document view itself — anything else is an overlay
-        if name ~= "ReaderUI" then
-            return true
-        end
-    end
-    return false
+    local top = UIManager:getTopmostVisibleWidget()
+    if not top then return false end
+    -- ReaderUI is the document view itself — anything else is an overlay.
+    -- getTopmostVisibleWidget skips widgets marked invisible — transient
+    -- decorations that paint but don't capture input, e.g. TrapWidget.
+    return (top.name or top.id) ~= "ReaderUI"
 end
 
 -- Set enabled state (global setting)


### PR DESCRIPTION
## Problem

`Pencil:isOverlayActive()` reads `UIManager._window_stack[#stack]` directly and treats any topmost widget whose name/id is not `ReaderUI` as an active overlay. It gates roughly a dozen stroke handlers (lines 328, 370, 1079, 1090, 1170, 1222, 1391, 1406, 2023, 2132, 2204, 2295), so when it returns true, inking is disabled globally.

This breaks compatibility with plugins that push transient, non-input-capturing widgets onto the window stack with `invisible = true`. KOReader's own helpers (`UIManager:getTopmostVisibleWidget` at `frontend/ui/uimanager.lua:780`) skip those widgets specifically because they "decorate but shouldn't count as overlays" (the docstring cites `TrapWidget` as the prototype). Pencil's direct stack read bypasses that contract.

## Concrete report

A user on r/koreader reported pencil's stylus input stops working on Kobo Libra Colour while [bookends.koplugin](https://github.com/AndyHazz/bookends.koplugin) is enabled. Bookends registers a `FlippingHaloOverlay` widget via `UIManager:show` to paint a page-coloured halo behind ReaderFlipping's top-left icon. It is marked `toast = true, invisible = true, covers_fullscreen = false` so KOReader's input dispatch and visibility checks skip it. Pencil's direct `_window_stack[#stack]` read does not, so it sees `BookendsFlippingHalo` instead of `ReaderUI` and trips the overlay gate.

A diagnostic build of bookends that omits the halo restored stylus input on the affected device, confirmed by the user. The fix below addresses the root cause in pencil and lets bookends keep its overlay.

## Fix

Use `UIManager:getTopmostVisibleWidget()`. It walks the stack top-down and returns the first widget with `invisible ~= true`, which is the canonical KOReader contract.

The change is semantics-preserving for everything that previously blocked pencil (menus, dialogs, confirm boxes, etc.); only invisible decoration widgets stop falsely triggering the gate.

## Testing

- Verified `UIManager:getTopmostVisibleWidget()` exists in current KOReader (`frontend/ui/uimanager.lua:780`).
- On-device verification with bookends + pencil is pending. Happy to ask the affected user to install a build of this branch and report back before merge.