### PR TITLE
[WIP] Fix strokes to page position on pdf files

### DIFF
--- a/pencil.koplugin/lib/geometry.lua
+++ b/pencil.koplugin/lib/geometry.lua
@@ -7,22 +7,22 @@ Pure functions for stroke geometry calculations.
 
 local Geometry = {}
 
---- Check if a point is near any point in a stroke.
+--- Check if a point is near any point in an array.
 -- Uses squared distance comparison to avoid sqrt for performance.
 -- @param px X coordinate of point to check
 -- @param py Y coordinate of point to check
--- @param stroke Table with points array
+-- @param points Array with points
 -- @param threshold Distance threshold (default 20)
 -- @return boolean True if point is within threshold of any stroke point
-function Geometry.isPointNearStroke(px, py, stroke, threshold)
-    if not stroke or not stroke.points then
+function Geometry.isPointNearPoints(px, py, points, threshold)
+    if not points then
         return false
     end
 
     threshold = threshold or 20
     local threshold_sq = threshold * threshold
 
-    for _, point in ipairs(stroke.points) do
+    for _, point in ipairs(points) do
         local dx = px - point.x
         local dy = py - point.y
         if dx * dx + dy * dy <= threshold_sq then

--- a/pencil.koplugin/main.lua
+++ b/pencil.koplugin/main.lua
@@ -2761,7 +2761,7 @@ function Pencil:pageToScreenPoints(stroke)
         if screen_rect ~= nil then
             table.insert(screen_points, { x = screen_rect.x, y = screen_rect.y })
         else
-            logger.dbg("Pencil: pageToScreenTransform returned nil for page", stroke.page,
+            logger.dbg("Pencil: pageToScreenTransform returned nil for page", page_point.page,
                 "point (", page_point.x, ",", page_point.y, ")")
         end
     end
@@ -3756,8 +3756,11 @@ function Pencil:drawHighlighterSegment(bb, x1, y1, x2, y2, width, color)
 end
 
 -- Check if a point is near a stroke (for eraser)
-function Pencil:isPointNearStroke(px, py, stroke, threshold)
-    return PencilGeometry.isPointNearStroke(px, py, stroke, threshold)
+function Pencil:isPointNearStroke(px, py, stroke, screen_points, threshold)
+    if not screen_points then
+        screen_points = self:pageToScreenPoints(stroke)
+    end
+    return PencilGeometry.isPointNearPoints(px, py, screen_points, threshold)
 end
 
 -- Erase strokes at a given point
@@ -3780,29 +3783,32 @@ function Pencil:eraseAtPoint(x, y, page)
     local deleted = {}
     local indices_to_remove = {}
 
-    -- Iterate only strokes on the current page via the page index. Keeps the
-    -- per-sample erase cost O(strokes-on-page) instead of O(total-strokes).
-    local page_indices = self.page_strokes and self.page_strokes[page] or nil
-    if page_indices then
-        for _, i in ipairs(page_indices) do
-            local stroke = self.strokes[i]
-            if stroke then
-                if self.input_debug_mode and stroke.points and #stroke.points > 0 then
-                    local min_x, max_x, min_y, max_y = stroke.points[1].x, stroke.points[1].x, stroke.points[1].y, stroke.points[1].y
-                    for _, pt in ipairs(stroke.points) do
-                        if pt.x < min_x then min_x = pt.x end
-                        if pt.x > max_x then max_x = pt.x end
-                        if pt.y < min_y then min_y = pt.y end
-                        if pt.y > max_y then max_y = pt.y end
+    -- Iterate only strokes on the current visible pages via the page index. 
+    -- Keeps the per-sample erase cost O(strokes-on-page) instead of O(total-strokes).
+    for _, p in ipairs(self.ui.view:getCurrentPageList()) do
+        local page_indices = self.page_strokes and self.page_strokes[p] or nil
+        if page_indices then
+            for _, i in ipairs(page_indices) do
+                local stroke = self.strokes[i]
+                if stroke then
+                    local points = self:pageToScreenPoints(stroke)
+                    if self.input_debug_mode and points and #points > 0 then
+                        local min_x, max_x, min_y, max_y = points[1].x, points[1].x, points[1].y, points[1].y
+                        for _, pt in ipairs(points) do
+                            if pt.x < min_x then min_x = pt.x end
+                            if pt.x > max_x then max_x = pt.x end
+                            if pt.y < min_y then min_y = pt.y end
+                            if pt.y > max_y then max_y = pt.y end
+                        end
+                        self:writeDebugLog(string.format("ERASE: stroke %d bounds: (%d-%d, %d-%d), eraser at (%d,%d) threshold=%d",
+                            i, min_x, max_x, min_y, max_y, x, y, eraser_width))
                     end
-                    self:writeDebugLog(string.format("ERASE: stroke %d bounds: (%d-%d, %d-%d), eraser at (%d,%d) threshold=%d",
-                        i, min_x, max_x, min_y, max_y, x, y, eraser_width))
-                end
-                if self:isPointNearStroke(x, y, stroke, eraser_width) then
-                    table.insert(deleted, stroke)
-                    table.insert(indices_to_remove, i)
-                    if self.input_debug_mode then
-                        self:writeDebugLog(string.format("ERASE: found stroke %d to delete", i))
+                    if self:isPointNearStroke(x, y, stroke, points, eraser_width) then
+                        table.insert(deleted, stroke)
+                        table.insert(indices_to_remove, i)
+                        if self.input_debug_mode then
+                            self:writeDebugLog(string.format("ERASE: found stroke %d to delete", i))
+                        end
                     end
                 end
             end

--- a/pencil.koplugin/main.lua
+++ b/pencil.koplugin/main.lua
@@ -1481,6 +1481,7 @@ function Pencil:onKeyPress(key)
 end
 
 function Pencil:onKeyRelease(key)
+    if key == nil then return false end
     local key_str = tostring(key)
 
     -- Always log key events when debug mode is on (even if not enabled)

--- a/pencil.koplugin/main.lua
+++ b/pencil.koplugin/main.lua
@@ -3785,7 +3785,11 @@ function Pencil:eraseAtPoint(x, y, page)
 
     -- Iterate only strokes on the current visible pages via the page index. 
     -- Keeps the per-sample erase cost O(strokes-on-page) instead of O(total-strokes).
-    for _, p in ipairs(self.ui.view:getCurrentPageList()) do
+    local page_list = self.view:getCurrentPageList()
+    if not page_list or #page_list < 1 then
+        page_list = { page }
+    end
+    for _, p in ipairs(page_list) do
         local page_indices = self.page_strokes and self.page_strokes[p] or nil
         if page_indices then
             for _, i in ipairs(page_indices) do
@@ -3958,7 +3962,11 @@ function Pencil:paintTo(bb, x, y)
     end
 
 
-    for _, p in ipairs(self.view:getCurrentPageList()) do
+    local page_list = self.view:getCurrentPageList()
+    if not page_list or #page_list < 1 then
+        page_list = { page }
+    end
+    for _, p in ipairs(page_list) do
         -- Render saved strokes for current page (skipping stale ones).
         local indices = self.page_strokes[p] or {}
         for _, idx in ipairs(indices) do

--- a/pencil.koplugin/main.lua
+++ b/pencil.koplugin/main.lua
@@ -1482,7 +1482,6 @@ function Pencil:onKeyPress(key)
 end
 
 function Pencil:onKeyRelease(key)
-    if key == nil then return false end
     local key_str = tostring(key)
 
     -- Always log key events when debug mode is on (even if not enabled)

--- a/pencil.koplugin/main.lua
+++ b/pencil.koplugin/main.lua
@@ -2741,13 +2741,7 @@ function Pencil:screenToPageStroke(stroke)
         if i == 1 then
             page_stroke.page = page_point.page
         end
-        if page_point.page == stroke.page then
-            table.insert(page_stroke.page_points, page_point)
-        else
-            -- Point is on a different page than the stroke's assigned page - drop it
-            logger.info("Pencil: Dropping point on", stroke.page,
-                "point (", page_point.x, ",", page_point.y, ")")
-        end
+        table.insert(page_stroke.page_points, page_point)
     end
     logger.info("Pencil: transformed stroke with", #stroke.points,
         "screen points to", #page_stroke.page_points, "page points on page", page_stroke.page)
@@ -2764,7 +2758,7 @@ function Pencil:pageToScreenPoints(stroke)
     local screen_points = {}
     for _, page_point in ipairs(stroke.page_points) do
         local page_rect = {x = page_point.x, y = page_point.y, w = 1,  h = 1}
-        local screen_rect = self.ui.view:pageToScreenTransform(stroke.page, page_rect)
+        local screen_rect = self.ui.view:pageToScreenTransform(page_point.page, page_rect)
         if screen_rect ~= nil then
             table.insert(screen_points, { x = screen_rect.x, y = screen_rect.y })
         else
@@ -3958,13 +3952,16 @@ function Pencil:paintTo(bb, x, y)
         }
     end
 
-    -- Render saved strokes for current page (skipping stale ones).
-    local indices = self.page_strokes[page] or {}
-    for _, idx in ipairs(indices) do
-        if not (stale_indices and stale_indices[idx]) then
-            local stroke = self.strokes[idx]
-            if stroke then
-                self:renderStroke(bb, stroke)
+
+    for _, p in ipairs(self.view:getCurrentPageList()) do
+        -- Render saved strokes for current page (skipping stale ones).
+        local indices = self.page_strokes[p] or {}
+        for _, idx in ipairs(indices) do
+            if not (stale_indices and stale_indices[idx]) then
+                local stroke = self.strokes[idx]
+                if stroke then
+                    self:renderStroke(bb, stroke)
+                end
             end
         end
     end

--- a/pencil.koplugin/main.lua
+++ b/pencil.koplugin/main.lua
@@ -714,8 +714,9 @@ function Pencil:endRawStroke()
             self.current_stroke and #self.current_stroke.points or 0))
     end
     if self.current_stroke and #self.current_stroke.points >= 1 then
-        table.insert(self.strokes, self.current_stroke)
-        self:indexStroke(#self.strokes, self.current_stroke.page)
+        local stroke = self:screenToPageStroke(self.current_stroke)
+        table.insert(self.strokes, stroke)
+        self:indexStroke(#self.strokes, stroke.page)
         table.insert(self.undo_stack, { type = "add", stroke_idx = #self.strokes })
         self:assignStrokeToGroup(#self.strokes)
         self:scheduleDeferredWork()
@@ -2536,11 +2537,10 @@ function Pencil:onDrawTap(ges)
         alpha = tool_settings.alpha,
         datetime = os.time(),
     }
-
+    stroke = self:screenToPageStroke(stroke)
     table.insert(self.strokes, stroke)
-    self:indexStroke(#self.strokes, page)
+    self:indexStroke(#self.strokes, stroke.page)
     self:saveStrokes()
-
     -- Add to undo stack
     table.insert(self.undo_stack, { type = "add", stroke_idx = #self.strokes })
 
@@ -2688,15 +2688,15 @@ function Pencil:onDrawPanRelease(ges)
     -- Fallback: finalize stroke via gesture system
     if #self.current_stroke.points >= 1 then
         -- Finalize the stroke
-        table.insert(self.strokes, self.current_stroke)
-        self:indexStroke(#self.strokes, self.current_stroke.page)
+        local stroke = self:screenToPageStroke(self.current_stroke)
+        table.insert(self.strokes, stroke)
+        self:indexStroke(#self.strokes, stroke.page)
         self:saveStrokes()
-
         -- Add to undo stack
         table.insert(self.undo_stack, { type = "add", stroke_idx = #self.strokes })
         self:assignStrokeToGroup(#self.strokes)
 
-        logger.dbg("Pencil: stroke completed with", #self.current_stroke.points, "points")
+        logger.dbg("Pencil: stroke completed with", #stroke.points, "points")
     end
 
     self.current_stroke = nil
@@ -2721,6 +2721,62 @@ function Pencil:getCurrentPage()
         -- Fallback to XPointer if conversion not available
         return xp
     end
+end
+
+-- Transforms a stroke in screen coordinates to page coordinates
+-- Only applies to paging documents (pdfs), otherwise returns stroke
+-- A stroke may span multiple pages
+-- If it does, points outside the first point's page will be dropped
+function Pencil:screenToPageStroke(stroke)
+    if not self.ui.paging or #stroke.points < 1 then
+        return stroke
+    end
+    local page_stroke = {}
+    for k, v in pairs(stroke) do
+        page_stroke[k] = v
+    end
+    page_stroke.page_points = {}
+    for i, point in ipairs(stroke.points) do
+        local page_point = self.ui.view:screenToPageTransform(point)
+        if i == 1 then
+            page_stroke.page = page_point.page
+        end
+        if page_point.page == stroke.page then
+            table.insert(page_stroke.page_points, page_point)
+        else
+            -- Point is on a different page than the stroke's assigned page - drop it
+            logger.info("Pencil: Dropping point on", stroke.page,
+                "point (", page_point.x, ",", page_point.y, ")")
+        end
+    end
+    logger.info("Pencil: transformed stroke with", #stroke.points,
+        "screen points to", #page_stroke.page_points, "page points on page", page_stroke.page)
+    return page_stroke
+end
+
+-- Transforms the page points of a stroke to screen coordinates
+-- Only applies to paging documents (pdfs), otherwise returns stroke.points
+-- Handle clipping of invidiual line segments to current view box
+function Pencil:pageToScreenPoints(stroke)
+    if not self.ui.paging or not stroke.page_points or #stroke.page_points < 1 then
+        return stroke.points
+    end
+    local screen_points = {}
+    for _, page_point in ipairs(stroke.page_points) do
+        local page_rect = {x = page_point.x, y = page_point.y, w = 1,  h = 1}
+        local screen_rect = self.ui.view:pageToScreenTransform(stroke.page, page_rect)
+        if screen_rect ~= nil then
+            table.insert(screen_points, { x = screen_rect.x, y = screen_rect.y })
+        else
+            logger.dbg("Pencil: pageToScreenTransform returned nil for page", stroke.page,
+                "point (", page_point.x, ",", page_point.y, ")")
+        end
+    end
+    if #screen_points < #stroke.page_points then
+        logger.info("Pencil: Only transformed", #screen_points, "of", #stroke.page_points,
+            "page points to screen points for stroke on page", stroke.page)
+    end
+    return screen_points
 end
 
 -- Index a stroke by page for quick lookup
@@ -3779,7 +3835,8 @@ end
 
 -- Render a complete stroke
 function Pencil:renderStroke(bb, stroke)
-    if not stroke.points or #stroke.points < 1 then
+    local points = self:pageToScreenPoints(stroke)
+    if not points or #points < 1 then
         return
     end
 
@@ -3801,16 +3858,16 @@ function Pencil:renderStroke(bb, stroke)
         color = stroke.color or Blitbuffer.Color8(0xDD)
     end
 
-    if #stroke.points == 1 then
+    if #points == 1 then
         -- Single point (dot)
-        local p = stroke.points[1]
+        local p = points[1]
         local half_w = math.floor(width / 2)
         bb:paintRectRGB32(p.x - half_w, p.y - half_w, width, width, color)
     else
         -- Multiple points - draw line segments
-        for i = 2, #stroke.points do
-            local p1 = stroke.points[i - 1]
-            local p2 = stroke.points[i]
+        for i = 2, #points do
+            local p1 = points[i - 1]
+            local p2 = points[i]
             if is_highlighter then
                 self:drawHighlighterSegment(bb, p1.x, p1.y, p2.x, p2.y, width, color)
             else
@@ -4011,6 +4068,7 @@ function Pencil:strokeToSaveable(stroke)
         datetime = stroke.datetime,
         points = stroke.points,
         color_name = stroke.color_name,  -- Save color name for persistence
+        page_points = stroke.page_points
     }
 end
 
@@ -4039,6 +4097,7 @@ function Pencil:strokeFromSaved(saved)
         alpha = saved.alpha or tool_settings.alpha,
         datetime = saved.datetime,
         points = saved.points,
+        page_points = saved.page_points
     }
 end
 
@@ -4106,8 +4165,9 @@ function Pencil:onCloseDocument()
     -- Save any in-progress stroke
     if self.current_stroke and #self.current_stroke.points >= 2 then
         logger.info("Pencil: saving in-progress stroke before close")
-        table.insert(self.strokes, self.current_stroke)
-        self:indexStroke(#self.strokes, self.current_stroke.page)
+        local stroke = self:screenToPageStroke(self.current_stroke)
+        table.insert(self.strokes, stroke)
+        self:indexStroke(#self.strokes, stroke.page)
         self.current_stroke = nil
     end
 
@@ -4187,8 +4247,9 @@ function Pencil:onPageUpdate(pageno)
         -- Save the stroke before clearing. The inline saveStrokes below covers
         -- everything in self.strokes, so drop any queued debounced save first.
         self:cancelPendingSave()
-        table.insert(self.strokes, self.current_stroke)
-        self:indexStroke(#self.strokes, self.current_stroke.page)
+        local stroke = self:screenToPageStroke(self.current_stroke)
+        table.insert(self.strokes, stroke)
+        self:indexStroke(#self.strokes, stroke.page)
         table.insert(self.undo_stack, { type = "add", stroke_idx = #self.strokes })
         self:flushDirtyGroups()
         self:saveStrokes()
@@ -4210,8 +4271,9 @@ function Pencil:onUpdatePos()
     -- Clear any in-progress stroke when position changes
     if self.current_stroke and #self.current_stroke.points >= 2 then
         self:cancelPendingSave()
-        table.insert(self.strokes, self.current_stroke)
-        self:indexStroke(#self.strokes, self.current_stroke.page)
+        local stroke = self:screenToPageStroke(self.current_stroke)
+        table.insert(self.strokes, stroke)
+        self:indexStroke(#self.strokes, stroke.page)
         table.insert(self.undo_stack, { type = "add", stroke_idx = #self.strokes })
         self:flushDirtyGroups()
         self:saveStrokes()

--- a/spec/erase_spec.lua
+++ b/spec/erase_spec.lua
@@ -33,8 +33,11 @@ local function createMockPencil(strokes, eraser_width)
     end
 
     -- Use real geometry function for point-near-stroke check
-    function mock:isPointNearStroke(px, py, stroke, threshold)
-        return Geometry.isPointNearStroke(px, py, stroke, threshold)
+    function mock:isPointNearStroke(px, py, stroke, screen_points, threshold)
+        if not screen_points then
+            screen_points = stroke.points
+        end
+        return Geometry.isPointNearPoints(px, py, screen_points, threshold)
     end
 
     -- Copy of eraseAtPoint from main.lua. Mirrors the page-indexed loop so this
@@ -52,7 +55,7 @@ local function createMockPencil(strokes, eraser_width)
         if page_indices then
             for _, i in ipairs(page_indices) do
                 local stroke = self.strokes[i]
-                if stroke and self:isPointNearStroke(x, y, stroke, eraser_width) then
+                if stroke and self:isPointNearStroke(x, y, stroke, nil, eraser_width) then
                     table.insert(deleted, stroke)
                     table.insert(indices_to_remove, i)
                 end

--- a/spec/eraser_button_spec.lua
+++ b/spec/eraser_button_spec.lua
@@ -68,8 +68,11 @@ local function createMockPencil(strokes, options)
     end
 
     -- Use real geometry function for point-near-stroke check
-    function mock:isPointNearStroke(px, py, stroke, threshold)
-        return Geometry.isPointNearStroke(px, py, stroke, threshold)
+    function mock:isPointNearStroke(px, py, stroke, screen_points, threshold)
+        if not screen_points then
+            screen_points = stroke.points
+        end
+        return Geometry.isPointNearPoints(px, py, screen_points, threshold)
     end
 
     -- Mock getCurrentPage
@@ -108,7 +111,7 @@ local function createMockPencil(strokes, options)
         end
 
         for i, stroke in ipairs(self.strokes) do
-            if stroke and isOnCurrentPage(stroke) and self:isPointNearStroke(x, y, stroke, eraser_width) then
+            if stroke and isOnCurrentPage(stroke) and self:isPointNearStroke(x, y, stroke, nil, eraser_width) then
                 table.insert(deleted, stroke)
                 table.insert(indices_to_remove, i)
             end

--- a/spec/geometry_spec.lua
+++ b/spec/geometry_spec.lua
@@ -13,24 +13,24 @@ describe("Geometry", function()
     describe("isPointNearStroke", function()
 
         it("returns false for nil stroke", function()
-            assert.is_false(Geometry.isPointNearStroke(0, 0, nil, 10))
+            assert.is_false(Geometry.isPointNearPoints(0, 0, nil, 10))
         end)
 
         it("returns false for stroke with nil points", function()
             local stroke = { points = nil }
-            assert.is_false(Geometry.isPointNearStroke(0, 0, stroke, 10))
+            assert.is_false(Geometry.isPointNearPoints(0, 0, stroke.points, 10))
         end)
 
         it("returns false for stroke with empty points", function()
             local stroke = { points = {} }
-            assert.is_false(Geometry.isPointNearStroke(0, 0, stroke, 10))
+            assert.is_false(Geometry.isPointNearPoints(0, 0, stroke.points, 10))
         end)
 
         it("returns true when point is exactly on stroke point", function()
             local stroke = {
                 points = { { x = 100, y = 200 } },
             }
-            assert.is_true(Geometry.isPointNearStroke(100, 200, stroke, 10))
+            assert.is_true(Geometry.isPointNearPoints(100, 200, stroke.points, 10))
         end)
 
         it("returns true when point is within threshold", function()
@@ -38,8 +38,8 @@ describe("Geometry", function()
                 points = { { x = 100, y = 200 } },
             }
             -- Point at distance 5 from stroke point
-            assert.is_true(Geometry.isPointNearStroke(105, 200, stroke, 10))
-            assert.is_true(Geometry.isPointNearStroke(100, 205, stroke, 10))
+            assert.is_true(Geometry.isPointNearPoints(105, 200, stroke.points, 10))
+            assert.is_true(Geometry.isPointNearPoints(100, 205, stroke.points, 10))
         end)
 
         it("returns false when point is outside threshold", function()
@@ -47,8 +47,8 @@ describe("Geometry", function()
                 points = { { x = 100, y = 200 } },
             }
             -- Point at distance > 10 from stroke point
-            assert.is_false(Geometry.isPointNearStroke(120, 200, stroke, 10))
-            assert.is_false(Geometry.isPointNearStroke(100, 220, stroke, 10))
+            assert.is_false(Geometry.isPointNearPoints(120, 200, stroke.points, 10))
+            assert.is_false(Geometry.isPointNearPoints(100, 220, stroke.points, 10))
         end)
 
         it("uses default threshold of 20", function()
@@ -56,9 +56,9 @@ describe("Geometry", function()
                 points = { { x = 100, y = 100 } },
             }
             -- Within default threshold of 20
-            assert.is_true(Geometry.isPointNearStroke(115, 100, stroke))
+            assert.is_true(Geometry.isPointNearPoints(115, 100, stroke.points))
             -- Outside default threshold of 20
-            assert.is_false(Geometry.isPointNearStroke(125, 100, stroke))
+            assert.is_false(Geometry.isPointNearPoints(125, 100, stroke.points))
         end)
 
         it("checks all points in stroke", function()
@@ -70,13 +70,13 @@ describe("Geometry", function()
                 },
             }
             -- Near first point
-            assert.is_true(Geometry.isPointNearStroke(5, 5, stroke, 10))
+            assert.is_true(Geometry.isPointNearPoints(5, 5, stroke.points, 10))
             -- Near middle point
-            assert.is_true(Geometry.isPointNearStroke(105, 105, stroke, 10))
+            assert.is_true(Geometry.isPointNearPoints(105, 105, stroke.points, 10))
             -- Near last point
-            assert.is_true(Geometry.isPointNearStroke(195, 5, stroke, 10))
+            assert.is_true(Geometry.isPointNearPoints(195, 5, stroke.points, 10))
             -- Not near any point
-            assert.is_false(Geometry.isPointNearStroke(100, 50, stroke, 10))
+            assert.is_false(Geometry.isPointNearPoints(100, 50, stroke.points, 10))
         end)
 
         it("handles boundary case (exactly at threshold)", function()
@@ -84,8 +84,8 @@ describe("Geometry", function()
                 points = { { x = 0, y = 0 } },
             }
             -- At exactly threshold distance (10 units away)
-            assert.is_true(Geometry.isPointNearStroke(10, 0, stroke, 10))
-            assert.is_true(Geometry.isPointNearStroke(0, 10, stroke, 10))
+            assert.is_true(Geometry.isPointNearPoints(10, 0, stroke.points, 10))
+            assert.is_true(Geometry.isPointNearPoints(0, 10, stroke.points, 10))
         end)
 
     end)


### PR DESCRIPTION
This pull request solves https://github.com/mysticknits/pencil.koplugin/issues/34
A new field "page_points" is stored in the strokes drawn on paged documents (PDF) with the points relative to the page.
When rendering this is used to calculate the page position.
I used Koreader ReaderView methods to transform from screen to page and page to screen.

Tested on my Kobo Libra Colour. Save persistence works, viewing multiple pages at the same time works, strokes spanning multiple pages work, strokes that are clipped offscreen work. Rotating does not work. Did not test epub but I expect this will work normally. Also did not test Zoom changes, but there is a good change that it will work.