### PR TITLE
Cut drawing lag in heavily-annotated books

### DIFF
--- a/pencil.koplugin/lib/geometry.lua
+++ b/pencil.koplugin/lib/geometry.lua
@@ -59,6 +59,18 @@ function Geometry.transformForRotation(x, y, rotation, screen_width, screen_heig
     return x, y  -- fallback for unknown rotation
 end
 
+--- Number of interpolation steps to rasterize a segment of length `dist`
+--- with a pen of the given width. Steps by ~half the width so consecutive
+--- width×width squares overlap enough to leave no gaps, without painting
+--- every pixel ~width times over (which is what stepping by 1px does).
+-- @param dist segment length in pixels
+-- @param width pen width in pixels
+-- @return number step count (>= 1)
+function Geometry.segmentStepCount(dist, width)
+    local step = math.max(1, math.floor(width / 2))
+    return math.max(1, math.ceil(dist / step))
+end
+
 --- Compute the bounding box of a stroke from its points array.
 -- @param stroke Table with points array (each point has x, y)
 -- @return table {x0, y0, x1, y1} or nil if no points

--- a/pencil.koplugin/lib/geometry.lua
+++ b/pencil.koplugin/lib/geometry.lua
@@ -59,6 +59,46 @@ function Geometry.transformForRotation(x, y, rotation, screen_width, screen_heig
     return x, y  -- fallback for unknown rotation
 end
 
+--- Pack a points array ({x=,y=} list) into a compact "x y x y ..." string.
+-- Saving points as tiny tables makes the serializer emit a key + indentation per
+-- element (tens of thousands of them); packing to one string per stroke keeps
+-- the serializer cost proportional to stroke count, not point count.
+-- @param points array of {x=, y=} (may be nil/empty)
+-- @return string space-separated coordinates ("" when empty)
+function Geometry.packPoints(points)
+    if not points or #points == 0 then return "" end
+    local buf = {}
+    local n = 0
+    for i = 1, #points do
+        local p = points[i]
+        n = n + 1; buf[n] = p.x or 0
+        n = n + 1; buf[n] = p.y or 0
+    end
+    return table.concat(buf, " ")
+end
+
+--- Inverse of packPoints: parse "x y x y ..." back into a {x=,y=} array.
+-- Tolerates ints, floats and negatives. Returns {} for nil/empty input.
+-- @param str packed string from packPoints
+-- @return array of {x=, y=}
+function Geometry.unpackPoints(str)
+    local points = {}
+    if not str or str == "" then return points end
+    local nums, k = {}, 0
+    for tok in str:gmatch("%S+") do
+        k = k + 1
+        nums[k] = tonumber(tok)
+    end
+    local pi = 0
+    for i = 1, k - 1, 2 do
+        if nums[i] and nums[i + 1] then
+            pi = pi + 1
+            points[pi] = { x = nums[i], y = nums[i + 1] }
+        end
+    end
+    return points
+end
+
 --- Number of interpolation steps to rasterize a segment of length `dist`
 --- with a pen of the given width. Steps by ~half the width so consecutive
 --- width×width squares overlap enough to leave no gaps, without painting

--- a/pencil.koplugin/main.lua
+++ b/pencil.koplugin/main.lua
@@ -4082,7 +4082,9 @@ function Pencil:strokeToSaveable(stroke)
         width = stroke.width,
         alpha = stroke.alpha,
         datetime = stroke.datetime,
-        points = stroke.points,
+        -- v4: points packed as a single "x y x y ..." string instead of an
+        -- array of {x=,y=} tables, so the serializer doesn't walk every point.
+        p = PencilGeometry.packPoints(stroke.points),
         color_name = stroke.color_name,  -- Save color name for persistence
     }
 end
@@ -4103,6 +4105,16 @@ function Pencil:strokeFromSaved(saved)
         end
     end
 
+    -- Points: v4 stores a packed "x y ..." string in `p`; v3 and earlier store
+    -- an array of {x=,y=} tables in `points`. Reconstruct the in-memory
+    -- {x=,y=} array either way.
+    local points
+    if saved.p ~= nil then
+        points = PencilGeometry.unpackPoints(saved.p)
+    else
+        points = saved.points or {}
+    end
+
     return {
         page = saved.page,
         tool = saved.tool,
@@ -4111,7 +4123,7 @@ function Pencil:strokeFromSaved(saved)
         color_name = saved.color_name,
         alpha = saved.alpha or tool_settings.alpha,
         datetime = saved.datetime,
-        points = saved.points,
+        points = points,
     }
 end
 
@@ -4147,11 +4159,12 @@ function Pencil:saveStrokes()
         saveable_strokes[i] = self:strokeToSaveable(stroke)
     end
 
-    -- Serialize and write. Version 3 marks files that may contain image_path /
-    -- image_rotation fields on annotation groups; older readers can ignore
-    -- those fields and continue to use the strokes directly.
+    -- Serialize and write. Version 4 packs each stroke's points into a single
+    -- "x y x y ..." string (field `p`) instead of an array of {x=,y=} tables,
+    -- cutting serialize time + file size on heavily-annotated documents. v3 and
+    -- earlier (points array) still load via strokeFromSaved's fallback.
     local data = {
-        version = 3,
+        version = 4,
         strokes = saveable_strokes,
         annotation_groups = self.annotation_groups,
     }

--- a/pencil.koplugin/main.lua
+++ b/pencil.koplugin/main.lua
@@ -94,6 +94,10 @@ local Pencil = InputContainer:extend{
     -- Delayed refresh - only refresh after user stops writing
     pending_refresh = nil,
     refresh_delay_ms = 600, -- Wait 600ms after last stroke before final refresh
+    -- Screen-space bbox of strokes drawn since the last delayed refresh fired.
+    -- The post-lift "clean" refresh is scoped to this region instead of the
+    -- whole screen, so a dense page doesn't trigger a full-panel e-ink update.
+    pending_refresh_bbox = nil,
 
     -- Debounced save - coalesces full O(N) serialization across consecutive strokes.
     -- Force-flushed on page change, close, and the deferred-work scheduler.
@@ -394,7 +398,12 @@ function Pencil:handleStylusSlot(input, slot)
                 end
                 self.view:paintTo(Screen.bb, 0, 0)
                 self:paintTo(Screen.bb, 0, 0)
-                Screen:refreshFast(0, 0, Screen:getWidth(), Screen:getHeight())
+                local rx, ry, rw, rh = self:erasedStrokesRefreshRect(deleted)
+                if rx then
+                    Screen:refreshFast(rx, ry, rw, rh)
+                else
+                    Screen:refreshFast(0, 0, Screen:getWidth(), Screen:getHeight())
+                end
             end
             -- Also remove any native KOReader text highlight at this position.
             -- removeItemByIndex emits AnnotationsModified and triggers its own
@@ -485,7 +494,12 @@ function Pencil:handleStylusSlot(input, slot)
                     -- Immediately repaint view and our strokes overlay, then refresh
                     self.view:paintTo(Screen.bb, 0, 0)
                     self:paintTo(Screen.bb, 0, 0)
-                    Screen:refreshUI(0, 0, Screen:getWidth(), Screen:getHeight())
+                    local rx, ry, rw, rh = self:erasedStrokesRefreshRect(deleted)
+                    if rx then
+                        Screen:refreshUI(rx, ry, rw, rh)
+                    else
+                        Screen:refreshUI(0, 0, Screen:getWidth(), Screen:getHeight())
+                    end
                     if self.input_debug_mode then
                         self:writeDebugLog(string.format("ERASED %d strokes at (%d, %d)", #deleted, x, y))
                     end
@@ -724,6 +738,9 @@ function Pencil:endRawStroke()
                 #self.strokes, #self.current_stroke.points, #self.strokes))
         end
         logger.dbg("Pencil: raw stroke ended with", #self.current_stroke.points, "points")
+        -- Track the region this stroke touched so the delayed refresh below
+        -- can be scoped to it instead of the whole screen.
+        self:accumulateRefreshBbox(self.current_stroke)
     else
         if self.input_debug_mode then
             self:writeDebugLog("endRawStroke: NOT SAVED (no current_stroke or no points)")
@@ -1718,18 +1735,55 @@ function Pencil:onDrawHold(ges)
     return true
 end
 
+-- Union a finished stroke's (screen-space) bounding box into the pending
+-- post-lift refresh region, expanded by the stroke's own half-width plus a
+-- small antialiasing pad. The delayed refresh then only updates this region.
+function Pencil:accumulateRefreshBbox(stroke)
+    if not stroke then return end
+    local bbox = PencilGeometry.computeStrokeBbox(stroke)
+    if not bbox then return end
+    local margin = math.floor((stroke.width or 0) / 2) + 4
+    bbox = PencilGeometry.bboxExpand(bbox, margin)
+    if self.pending_refresh_bbox then
+        self.pending_refresh_bbox = PencilGeometry.bboxUnion(self.pending_refresh_bbox, bbox)
+    else
+        self.pending_refresh_bbox = bbox
+    end
+end
+
 -- Schedule a delayed refresh after writing stops
 function Pencil:scheduleDelayedRefresh()
     -- Cancel any existing pending refresh
     self:cancelPendingRefresh()
 
-    -- Schedule new refresh
-    self.pending_refresh = UIManager:scheduleIn(self.refresh_delay_ms / 1000, function()
-        self.pending_refresh = nil
-        -- Do a fast refresh of the whole view to show all recent strokes
-        UIManager:setDirty(self.view, "fast")
+    -- Schedule new refresh. Store the closure itself (not scheduleIn's nil
+    -- return) so cancelPendingRefresh can actually unschedule it.
+    local action
+    action = function()
+        if self.pending_refresh == action then self.pending_refresh = nil end
+        local bbox = self.pending_refresh_bbox
+        self.pending_refresh_bbox = nil
+        if bbox then
+            -- Scope the fast refresh to the region the recent strokes touched.
+            -- The view still repaints fully, but the slow e-ink update is small.
+            bbox = PencilGeometry.bboxClampToScreen(bbox, Screen:getWidth(), Screen:getHeight())
+            local rw = bbox.x1 - bbox.x0
+            local rh = bbox.y1 - bbox.y0
+            if rw > 0 and rh > 0 then
+                local region = Geom:new{ x = bbox.x0, y = bbox.y0, w = rw, h = rh }
+                UIManager:setDirty(self.view, "fast", region)
+            else
+                UIManager:setDirty(self.view, "fast")
+            end
+        else
+            -- No tracked region (e.g. refresh scheduled without a finished
+            -- stroke) — fall back to a full-view fast refresh.
+            UIManager:setDirty(self.view, "fast")
+        end
         logger.dbg("Pencil: delayed refresh triggered")
-    end)
+    end
+    self.pending_refresh = action
+    UIManager:scheduleIn(self.refresh_delay_ms / 1000, action)
 end
 
 -- Cancel pending refresh (called when new stroke starts)
@@ -1741,13 +1795,20 @@ function Pencil:cancelPendingRefresh()
 end
 
 -- Schedule a debounced save + bookmark flush after writing pauses.
+-- NOTE: UIManager:scheduleIn() returns nil, and UIManager:unschedule() matches
+-- by the action function reference. So we must store the closure itself in
+-- pending_save (not scheduleIn's return value) or cancelPendingSave can never
+-- cancel it — which previously caused one full save to fire per stroke.
 function Pencil:scheduleDeferredWork()
     self:cancelPendingSave()
-    self.pending_save = UIManager:scheduleIn(self.save_delay_ms / 1000, function()
-        self.pending_save = nil
+    local action
+    action = function()
+        if self.pending_save == action then self.pending_save = nil end
         self:flushDirtyGroups()
         self:saveStrokes()
-    end)
+    end
+    self.pending_save = action
+    UIManager:scheduleIn(self.save_delay_ms / 1000, action)
 end
 
 function Pencil:cancelPendingSave()
@@ -2589,7 +2650,12 @@ function Pencil:onDrawPan(ges)
                 table.insert(self.eraser_deleted, stroke)
             end
             self.view:paintTo(Screen.bb, 0, 0)
-            Screen:refreshUI()
+            local rx, ry, rw, rh = self:erasedStrokesRefreshRect(deleted)
+            if rx then
+                Screen:refreshUI(rx, ry, rw, rh)
+            else
+                Screen:refreshUI()
+            end
         end
         return true
     end
@@ -2696,6 +2762,7 @@ function Pencil:onDrawPanRelease(ges)
         self:assignStrokeToGroup(#self.strokes)
 
         logger.dbg("Pencil: stroke completed with", #self.current_stroke.points, "points")
+        self:accumulateRefreshBbox(self.current_stroke)
     end
 
     self.current_stroke = nil
@@ -3655,22 +3722,23 @@ function Pencil:clearAllStrokes()
 end
 
 -- Render a line segment using rectangles (since BlitBuffer has no native line drawing)
-function Pencil:drawLineSegment(bb, x1, y1, x2, y2, width, color)
+-- Rasterize a thick line by stamping width×width squares along the segment.
+-- Steps by ~half the pen width (via Geometry.segmentStepCount) so the squares
+-- overlap without the ~width-fold per-pixel overdraw that stepping by 1px gives.
+function Pencil:drawThickLine(bb, x1, y1, x2, y2, width, color)
     local dx = x2 - x1
     local dy = y2 - y1
     local dist = math.sqrt(dx * dx + dy * dy)
+    local half_w = math.floor(width / 2)
 
     if dist < 1 then
         -- Just draw a single point
-        local half_w = math.floor(width / 2)
         bb:paintRectRGB32(x1 - half_w, y1 - half_w, width, width, color)
         return
     end
 
-    -- Step along the line drawing small rectangles
-    local steps = math.ceil(dist)
-    local half_w = math.floor(width / 2)
-
+    -- Inclusive 0..steps loop emits both endpoints (t=0 and t=1).
+    local steps = PencilGeometry.segmentStepCount(dist, width)
     for i = 0, steps do
         local t = i / steps
         local x = math.floor(x1 + dx * t)
@@ -3679,35 +3747,41 @@ function Pencil:drawLineSegment(bb, x1, y1, x2, y2, width, color)
     end
 end
 
+function Pencil:drawLineSegment(bb, x1, y1, x2, y2, width, color)
+    self:drawThickLine(bb, x1, y1, x2, y2, width, color)
+end
+
 -- Render a highlighter segment (semi-transparent, wider)
 function Pencil:drawHighlighterSegment(bb, x1, y1, x2, y2, width, color)
-    local dx = x2 - x1
-    local dy = y2 - y1
-    local dist = math.sqrt(dx * dx + dy * dy)
-
     -- Highlighter is drawn as a lighter gray to simulate transparency on e-ink
     local highlight_color = color or Blitbuffer.Color8(0xDD)
-
-    if dist < 1 then
-        local half_w = math.floor(width / 2)
-        bb:paintRectRGB32(x1 - half_w, y1 - half_w, width, width, highlight_color)
-        return
-    end
-
-    local steps = math.ceil(dist)
-    local half_w = math.floor(width / 2)
-
-    for i = 0, steps do
-        local t = i / steps
-        local x = math.floor(x1 + dx * t)
-        local y = math.floor(y1 + dy * t)
-        bb:paintRectRGB32(x - half_w, y - half_w, width, width, highlight_color)
-    end
+    self:drawThickLine(bb, x1, y1, x2, y2, width, highlight_color)
 end
 
 -- Check if a point is near a stroke (for eraser)
 function Pencil:isPointNearStroke(px, py, stroke, threshold)
     return PencilGeometry.isPointNearStroke(px, py, stroke, threshold)
+end
+
+-- Screen-space refresh rect (x, y, w, h) covering a set of just-deleted
+-- strokes, expanded by the eraser width and clamped to the screen. Returns
+-- nil when no stroke has geometry, signalling the caller to refresh fully.
+function Pencil:erasedStrokesRefreshRect(strokes)
+    local bbox = nil
+    for _, s in ipairs(strokes) do
+        local b = PencilGeometry.computeStrokeBbox(s)
+        if b then
+            bbox = bbox and PencilGeometry.bboxUnion(bbox, b) or b
+        end
+    end
+    if not bbox then return nil end
+    local margin = (self.tool_settings[TOOL_ERASER] and self.tool_settings[TOOL_ERASER].width) or 20
+    bbox = PencilGeometry.bboxExpand(bbox, margin)
+    bbox = PencilGeometry.bboxClampToScreen(bbox, Screen:getWidth(), Screen:getHeight())
+    local w = bbox.x1 - bbox.x0
+    local h = bbox.y1 - bbox.y0
+    if w <= 0 or h <= 0 then return nil end
+    return bbox.x0, bbox.y0, w, h
 end
 
 -- Erase strokes at a given point

--- a/spec/geometry_spec.lua
+++ b/spec/geometry_spec.lua
@@ -307,4 +307,31 @@ describe("Geometry", function()
         end)
     end)
 
+    describe("segmentStepCount", function()
+
+        it("steps by ~half the width for thick pens", function()
+            -- width 10 -> step 5; dist 100 -> ceil(100/5) = 20
+            assert.are.equal(20, Geometry.segmentStepCount(100, 10))
+        end)
+
+        it("never returns less than 1 step", function()
+            assert.are.equal(1, Geometry.segmentStepCount(0, 10))
+            assert.are.equal(1, Geometry.segmentStepCount(2, 10))
+        end)
+
+        it("falls back to 1px steps for thin pens (width <= 2)", function()
+            -- floor(2/2) = 1 -> step 1 -> ceil(100/1) = 100
+            assert.are.equal(100, Geometry.segmentStepCount(100, 2))
+            -- floor(1/2) = 0 -> max(1, 0) = 1 -> ceil(100/1) = 100
+            assert.are.equal(100, Geometry.segmentStepCount(100, 1))
+        end)
+
+        it("produces far fewer steps than the old 1px stepping for wide pens", function()
+            local dist = 300
+            local old_steps = math.ceil(dist)  -- previous behaviour
+            local new_steps = Geometry.segmentStepCount(dist, 12)
+            assert.is_true(new_steps < old_steps / 4)
+        end)
+    end)
+
 end)

--- a/spec/geometry_spec.lua
+++ b/spec/geometry_spec.lua
@@ -307,6 +307,37 @@ describe("Geometry", function()
         end)
     end)
 
+    describe("packPoints / unpackPoints", function()
+
+        it("returns empty string for nil/empty points", function()
+            assert.are.equal("", Geometry.packPoints(nil))
+            assert.are.equal("", Geometry.packPoints({}))
+        end)
+
+        it("returns empty array for nil/empty string", function()
+            assert.are.same({}, Geometry.unpackPoints(nil))
+            assert.are.same({}, Geometry.unpackPoints(""))
+        end)
+
+        it("round-trips a points array exactly", function()
+            local pts = { {x=1, y=2}, {x=345, y=678}, {x=0, y=0} }
+            local packed = Geometry.packPoints(pts)
+            assert.are.equal("1 2 345 678 0 0", packed)
+            assert.are.same(pts, Geometry.unpackPoints(packed))
+        end)
+
+        it("round-trips negative and fractional coordinates", function()
+            local pts = { {x=-5, y=10}, {x=3.5, y=-2.25} }
+            assert.are.same(pts, Geometry.unpackPoints(Geometry.packPoints(pts)))
+        end)
+
+        it("handles a large stroke", function()
+            local pts = {}
+            for i = 1, 500 do pts[i] = { x = i, y = i * 2 } end
+            assert.are.same(pts, Geometry.unpackPoints(Geometry.packPoints(pts)))
+        end)
+    end)
+
     describe("segmentStepCount", function()
 
         it("steps by ~half the width for thick pens", function()


### PR DESCRIPTION
## Problem

On the Kobo Libra Colour, drawing in books with lots of annotations froze mid-word — writing "what" would stall ~1s before "at" appeared. Profiling on a real 3.6 MB / 620-stroke book pinned the cause to `saveStrokes` blocking the main thread.

## Root cause: the save debounce never worked

`scheduleDeferredWork`/`scheduleDelayedRefresh` stored `UIManager:scheduleIn(...)`'s return value (always `nil`) in `pending_save`, but `unschedule()` matches by the **action function reference**. So `cancelPendingSave` never cancelled anything, and **every stroke scheduled its own full save**. Instrumentation showed 17 saves in 9s of writing, each a 250–480ms `dump()` + write.

Fix: store the action closure itself so the debounce coalesces to a single save ~1.5s after writing stops.

## Make the save itself cheap (format v4)

Even one save was ~300ms: `dump()` walked every point as a `{x=,y=}` table, emitting a key + indentation per element. Points are now packed into a single `"x y x y ..."` string per stroke (field `p`, version 4).

Measured on the real 620-stroke / 30k-point file:
- **18× faster** to serialize (≈300ms → ~20ms on-device)
- **8× smaller** (3.5 MB → 0.43 MB)

In-memory representation is unchanged (`{x=,y=}` arrays), so rendering/erase/bbox are untouched. `strokeFromSaved` falls back to the v3 `points` array, so existing files load unchanged and auto-migrate to v4 on the next save.

## Also included (same drawing path, smaller wins)

- Scope the post-lift "clean" refresh to the finished strokes' bbox instead of a full-screen e-ink update.
- Scope the three eraser refreshes to the erased region.
- Rasterizer: step thick lines by ~½ the pen width (`Geometry.segmentStepCount` + shared `drawThickLine`) instead of 1px, cutting ~W/2× of `paintRectRGB32` overdraw per segment.

## Testing

- 166 busted specs pass, including new `segmentStepCount` and `packPoints`/`unpackPoints` round-trip tests.
- Benchmarked the v4 serialization against the real on-device stroke file (round-trip verified exact).
- Verified on-device (Kobo Libra Colour): drawing no longer freezes mid-word; existing annotations load and migrate to v4 correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)